### PR TITLE
kitakami: Let cameraservice close native handles

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -105,6 +105,7 @@ SNDRV_COMPRESS_SET_NEXT_TRACK_PARAM := true
 
 # We use stock camera blobs
 USE_CAMERA_STUB := true
+TARGET_CAMERASERVICE_CLOSES_NATIVE_HANDLES := true
 
 # Disable dex-preoptimization
 WITH_DEXPREOPT := false


### PR DESCRIPTION
 * Our current camera HAL doesn't close native handles internally,
   causing video recording to freeze after ~30s.
 * When setting this flag we ensure that cameraservice becomes
   responsible for such actions, thus fixing the camcorder issues.
 * Revert when camera HAL is updated with proper support.

Change-Id: I2d36728d4b05d1a38408e1c072e8c33dfb091ef8